### PR TITLE
Fix session key issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Thumbs.db
 .DS_Store
 *.db
 users.db
+.session-key
 
 # exclude image_archive and cex
 static/image_archive/*


### PR DESCRIPTION
Closes issue #25.

### Functionality this PR provides:

* generate a session key _once_ at first startup and store it in a local, hidden file named `.session-key` within the parent directory of the binary
  * if the file does not exist or is corrupted, generate a new key instead

### How to test:

* clear all brucheion cookies. build the binary and visit brucheion, login. restart the server and reload the page. the session should be preserved.