### PR TITLE
Open Brucheion in default browser at startup

### DIFF
--- a/brucheion.go
+++ b/brucheion.go
@@ -76,9 +76,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = open.Start(config.Host)
-	if err != nil {
-		log.Println(err)
+	if Version != "development" {
+		err = open.Start(config.Host)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 
 	log.Fatal(http.Serve(l, router))

--- a/brucheion.go
+++ b/brucheion.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"net"
 	"net/http"
 	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/markbates/pkger"
+	"github.com/skratchdot/open-golang/open"
 )
 
 //The configuration that is needed for for the cookiestore. Holds Host information and provider secrets.
@@ -66,11 +68,20 @@ func main() {
 		log.Println("Started in noAuth mode.")
 	}
 
-	//Create new router instance with associated routes
-	router := setUpRouter()
+	router := createRouter()
 
-	log.Println("Listening at " + config.Host + "...")
-	log.Fatal(http.ListenAndServe(config.Port, router))
+	log.Printf("Listening at %s\n", config.Host)
+	l, err := net.Listen("tcp", config.Port)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = open.Start(config.Host)
+	if err != nil {
+		log.Println(err)
+	}
+
+	log.Fatal(http.Serve(l, router))
 }
 
 //landingPage is the first landing page for experimental testing
@@ -115,7 +126,7 @@ func landingPage(res http.ResponseWriter, req *http.Request) {
 	renderTemplate(res, "main", page)
 }
 
-func setUpRouter() *mux.Router {
+func createRouter() *mux.Router {
 	//Start the router
 	router := mux.NewRouter().StrictSlash(true)
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/markbates/goth v1.64.2
 	github.com/markbates/pkger v0.17.0
 	github.com/pkg/errors v0.8.1
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/tj/go-update v2.2.4+incompatible
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
 github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=


### PR DESCRIPTION
### Functionality this PR provides:

* Launch Brucheion via its URL in the default browser ([open/start/xdg-open](https://github.com/skratchdot/open-golang/))

### How to test:

* Build and start Brucheion